### PR TITLE
Fixing python3 compatibility and README update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Installation
 ```sh
 $ pip install pyomegle
 ```
-pyomegle depends on [mechanize](http://wwwsearch.sourceforge.net/mechanize/). For this reason Python 3 is currently not supported.
 
 Usage
 ==================

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ c = OmegleClient(h, wpm=47, lang='en')  # 47 words per minute
 c.start()
 
 while 1:
-    input_str = raw_input('')           # string input
+    input_str = input('')           # string input
 
     if input_str.strip() == '/next':
         c.next()                        # new conversation

--- a/pyomegle/__init__.py
+++ b/pyomegle/__init__.py
@@ -1,1 +1,1 @@
-from pyomegle import *
+from .pyomegle import *

--- a/pyomegle/pyomegle.py
+++ b/pyomegle/pyomegle.py
@@ -143,7 +143,7 @@ class Omegle(object):
             assert 'URL not valid for request'
 
         if data:
-            data = urllib.urlencode(data)
+            data = urllib.parse.urlencode(data)
 
         response = self.browser.open(url, data)
 
@@ -178,7 +178,7 @@ class Omegle(object):
                                 self.spid, self.random_id, self.lang)
         if self.topics:
             # Add custom topic to the url
-            url += '&' + urllib.urlencode({'topics': json.dumps(self.topics)})
+            url += '&' + urllib.parse.urlencode({'topics': json.dumps(self.topics)})
 
         thread = EventThread(self, url)
         thread.start()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='pyomegle',
-      version='1.05',
+      version='1.06',
       description='Python API for Omegle webchat',
       long_description='Python API for Omegle webchat. \
                         Usage: https://github.com/elias94/pyomegle',


### PR DESCRIPTION
Urlencode is now exposed through the parse module of urllib.

Mechanize is now compatible with python3.

Updated the usage to be python3 compatible.

Fixed the imports so they now work with python3's strict relative imports.

Updated version incase that was needed.