### PR TITLE
Typing time equation had wpm flipped.

### DIFF
--- a/pyomegle/pyomegle.py
+++ b/pyomegle/pyomegle.py
@@ -325,7 +325,7 @@ class OmegleClient(Omegle):
 
     def _typingtime(self, msglen):
         """ Calculates typing time in WPM """
-        return (self.wpm / 60) * (msglen / 5)
+        return (60 / self.wpm) * (msglen / 5)
 
     def write(self, message):
         """ Simulates a message completely written """


### PR DESCRIPTION
`_typingtime` method in `OmegleClient` is written incorrectly.

The equation should be

```python
(60 / self.wpm) * (msglen / 5)
```
60 being seconds in a minute, 5 being the average amount of letters in a word for English. So the equation simplified is (Words per second) * (Approximate words in message).